### PR TITLE
Recursive diff: add simple filter option

### DIFF
--- a/Sources/LoggerMiddleware/LoggerMiddleware.swift
+++ b/Sources/LoggerMiddleware/LoggerMiddleware.swift
@@ -221,12 +221,10 @@ extension LoggerMiddleware {
         })
         .compactMap { $0 }
         .filter { (diffLine: String) -> Bool in
-            if nil == filters?.first(where: { filterString in
+            // filter diffLine if it contains a filterString
+            nil == filters?.first(where: { filterString in
                 diffLine.contains(filterString)
-            }) {
-                return true
-            }
-            return false
+            })
         }
 
         if strings.count > 0 {

--- a/Sources/LoggerMiddleware/LoggerMiddleware.swift
+++ b/Sources/LoggerMiddleware/LoggerMiddleware.swift
@@ -222,7 +222,7 @@ extension LoggerMiddleware {
         .compactMap { $0 }
         .filter { (diffLine: String) -> Bool in
             // filter diffLine if it contains a filterString
-            nil == filters?.first(where: { filterString in
+            false == (filters ?? []).contains(where: { filterString in
                 diffLine.contains(filterString)
             })
         }

--- a/Tests/LoggerMiddlewareTests/LoggerMiddlewareTests.swift
+++ b/Tests/LoggerMiddlewareTests/LoggerMiddlewareTests.swift
@@ -67,6 +67,48 @@ final class LoggerMiddlewareTests: XCTestCase {
         XCTAssertEqual(result, expected)
     }
 
+
+    func testStateDiffWithFilters() {
+        // given
+        let beforeState: LoggerMiddleware<TestMiddleware>.StateType = TestState(a: Substate(x: ["SetB", "SetA"],
+                                                                                            y1: ["one": 1, "eleven": 11],
+                                                                                            y2: ["one": 1, "eleven": 11, "zapp": 42],
+                                                                                            z: true),
+                                                                                b: [0, 1],
+                                                                                c: "Foo",
+                                                                                d: "✨",
+                                                                                e: nil)
+        let afterState: LoggerMiddleware<TestMiddleware>.StateType = TestState(a: Substate(x: ["SetB", "SetC"],
+                                                                                           y1: ["one": 1, "twelve": 12],
+                                                                                           y2: ["one": 1, "twelve": 12, "zapp": nil],
+                                                                                           z: false),
+                                                                                b: [0],
+                                                                                c: "Bar",
+                                                                                d: nil,
+                                                                                e: "🥚")
+
+        // when
+        let result: String? = LoggerMiddleware<TestMiddleware>.recursiveDiff(prefixLines: "🏛",
+                                                                             stateName: "TestState",
+                                                                             filters: [
+                                                                                " TestState.a.y2",
+                                                                                " TestState.b.#"
+                                                                             ],
+                                                                             before: beforeState,
+                                                                             after: afterState)
+
+        // then
+        let expected = """
+                       🏛 TestState.a.x: 📦 <SetA, SetB> → <SetB, SetC>
+                       🏛 TestState.a.y1: 📦 [eleven: 11, one: 1] → [one: 1, twelve: 12]
+                       🏛 TestState.a.z: true → false
+                       🏛 TestState.c: Foo → Bar
+                       🏛 TestState.d.some: ✨ → nil
+                       🏛 TestState.e: nil → Optional("🥚")
+                       """
+        XCTAssertEqual(result, expected)
+    }
+
     static var allTests = [
         ("testStateDiff", testStateDiff),
     ]


### PR DESCRIPTION
- allows excluding of "noisy" collections
- no regex, plain string matching